### PR TITLE
Code of conduct

### DIFF
--- a/doc/00-CodeOfConduct.md
+++ b/doc/00-CodeOfConduct.md
@@ -1,0 +1,54 @@
+# Brendel Group Code of Conduct
+
+As contributors and maintainers of Brendel Group research software projects, and
+in the interest of fostering an open and welcoming community, we pledge to
+respect all people who contribute through reporting issues, posting feature
+requests, updating documentation, submitting pull requests or patches, and other
+activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+- Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting one of the project maintainers: Volker Brendel at
+<vbrendel@indiana.edu>, Taylor Raborn at <rtraborn@indiana.edu>, or Daniel
+Standage at <dstandag@indiana.edu>. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. Maintainers are obligated to maintain
+confidentiality with regard to the reporter of an incident. Violations of the
+code of conduct by one of the project maintainers may be reported in confidence
+to CONTACT at EMAILADDRESS.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/


### PR DESCRIPTION
As far as I'm aware, we've never had any serious issues with conduct in the lab, nor do we expect any. However, bad apples have made some corners of academic science and online communities very unwelcoming for women and other underrepresented groups. A code of conduct has become a standard mechanism for explicitly pledging to make a community or project a welcoming and respectful space.

This pull request is not ready to be accepted yet. I have someone in mind for a third-party contact, but would like to discuss this in person, and obviously we would need their permission.