### PR TITLE
Fix link to asciicast

### DIFF
--- a/doc/02-Howto-UNIX.md
+++ b/doc/02-Howto-UNIX.md
@@ -285,4 +285,4 @@ However, if there is a problem, hopefully the last few lines of output will make
 The more experience you get with this, the easier it will be to recognize.
 
 Take a look at the terminal recording below for a simple example of a typical software installation.
-<script type="text/javascript" src="https://asciinema.org/a/2077.js" id="asciicast-2077" async></script>
+[![asciicast](https://asciinema.org/a/2077.png)](https://asciinema.org/a/2077)


### PR DESCRIPTION
The `<script>` tag to embed the "video" player was likely copied from Dokuwiki, where it rendered properly. Github strips out script tags for security, so we'll have to settle with an image link to the video on the hosting site.